### PR TITLE
Update nmf_output() in source_separation.py

### DIFF
--- a/soundscape_viewer/source_separation.py
+++ b/soundscape_viewer/source_separation.py
@@ -312,7 +312,7 @@ class supervised_nmf:
       source = self.reconstruct(source=run+1) #np.dot(self.W[:,self.W_cluster==run],self.H[self.W_cluster==run,:])
       mask=np.divide(source,source0)
       mask[np.isnan(mask)]=0
-      separation[run] = np.hstack((time_vec, np.multiply(data,mask).T+baseline))
+      separation[run] = np.hstack((np.reshape(time_vec,(-1,1)), np.multiply(data,mask).T+baseline))
       relative_level[run] = 10*np.log10((10**(separation[run][:,1:]/10)).sum(axis=1))
     self.separation=separation
     self.relative_level=relative_level

--- a/soundscape_viewer/source_separation.py
+++ b/soundscape_viewer/source_separation.py
@@ -337,7 +337,7 @@ class supervised_nmf:
       W=np.array(self.W[:,W_list])
         
     # Plot
-    x_lim=np.array([self.time_vec[H_list[0]][0], self.time_vec[H_list[-1]][0]])
+    x_lim=np.array([self.time_vec[H_list[0]], self.time_vec[H_list[-1]]])
     fig, ax = plt.subplots(figsize=(fig_width, fig_height))
     if plot_type=='W':
       im = ax.imshow(W, origin='lower',  aspect='auto', cmap=cm.jet,


### PR DESCRIPTION
time_vec is a 1d array which can not hstack with a 2d array.
Therefore, by reshaping time_vec, we're able to hstack time_vec and the reconstruction spectrogram.
`separation[run] = np.hstack((np.reshape(time_vec,(-1,1)), np.multiply(data,mask).T+baseline))`
and x_lim require corresponding modify.